### PR TITLE
Using hook for resource pack kicking

### DIFF
--- a/src/Bindings/Plugin.h
+++ b/src/Bindings/Plugin.h
@@ -101,6 +101,7 @@ public:
 	virtual bool OnPreCrafting              (cPlayer & a_Player, cCraftingGrid & a_Grid, cCraftingRecipe & a_Recipe) = 0;
 	virtual bool OnProjectileHitBlock       (cProjectileEntity & a_Projectile, int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_Face, const Vector3d & a_BlockHitPos) = 0;
 	virtual bool OnProjectileHitEntity      (cProjectileEntity & a_Projectile, cEntity & a_HitEntity) = 0;
+	virtual bool OnResourcePack             (const UInt8 a_Status) = 0;
 	virtual bool OnServerPing               (cClientHandle & a_ClientHandle, AString & a_ServerDescription, int & a_OnlinePlayersCount, int & a_MaxPlayersCount, AString & a_Favicon) = 0;
 	virtual bool OnSpawnedEntity            (cWorld & a_World, cEntity & a_Entity) = 0;
 	virtual bool OnSpawnedMonster           (cWorld & a_World, cMonster & a_Monster) = 0;

--- a/src/Bindings/PluginLua.cpp
+++ b/src/Bindings/PluginLua.cpp
@@ -880,6 +880,15 @@ bool cPluginLua::OnProjectileHitEntity(cProjectileEntity & a_Projectile, cEntity
 
 
 
+bool cPluginLua::OnResourcePack(const UInt8 a_Status)
+{
+	return CallSimpleHooks(cPluginManager::HOOK_RESOURCEPACK, a_Status);
+}
+
+
+
+
+
 bool cPluginLua::OnServerPing(cClientHandle & a_ClientHandle, AString & a_ServerDescription, int & a_OnlinePlayersCount, int & a_MaxPlayersCount, AString & a_Favicon)
 {
 	cOperation op(*this);

--- a/src/Bindings/PluginLua.h
+++ b/src/Bindings/PluginLua.h
@@ -122,6 +122,7 @@ public:
 	virtual bool OnPreCrafting              (cPlayer & a_Player, cCraftingGrid & a_Grid, cCraftingRecipe & a_Recipe) override;
 	virtual bool OnProjectileHitBlock       (cProjectileEntity & a_Projectile, int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_Face, const Vector3d & a_BlockHitPos) override;
 	virtual bool OnProjectileHitEntity      (cProjectileEntity & a_Projectile, cEntity & a_HitEntity) override;
+	virtual bool OnResourcePack             (const UInt8 a_Status) override;
 	virtual bool OnServerPing               (cClientHandle & a_ClientHandle, AString & a_ServerDescription, int & a_OnlinePlayersCount, int & a_MaxPlayersCount, AString & a_Favicon) override;
 	virtual bool OnSpawnedEntity            (cWorld & a_World, cEntity & a_Entity) override;
 	virtual bool OnSpawnedMonster           (cWorld & a_World, cMonster & a_Monster) override;

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -338,8 +338,7 @@ bool cPluginManager::CallHookChat(cPlayer & a_Player, AString & a_Message)
 			a_Player.SendMessageFailure(Printf("Something went wrong while executing command \"%s\"", a_Message.c_str()));
 			return true;
 		}
-
-		case crNoPermission:
+case crNoPermission:
 		{
 			// The player is not allowed to execute this command
 			a_Player.SendMessageFailure(Printf("Forbidden command; insufficient privileges: \"%s\"", a_Message.c_str()));
@@ -1091,6 +1090,18 @@ bool cPluginManager::CallHookProjectileHitEntity(cProjectileEntity & a_Projectil
 			return a_Plugin->OnProjectileHitEntity(a_Projectile, a_HitEntity);
 		}
 	);
+}
+
+
+
+
+
+bool cPluginManager::CallHookResourcePack(const UInt8 a_Status)
+{
+	return GenericCallHook(HOOK_RESOURCEPACK, [&](cPlugin * a_Plugin){
+				return a_Plugin->OnResourcePack(a_Status);
+			}
+		);
 }
 
 

--- a/src/Bindings/PluginManager.cpp
+++ b/src/Bindings/PluginManager.cpp
@@ -338,7 +338,8 @@ bool cPluginManager::CallHookChat(cPlayer & a_Player, AString & a_Message)
 			a_Player.SendMessageFailure(Printf("Something went wrong while executing command \"%s\"", a_Message.c_str()));
 			return true;
 		}
-case crNoPermission:
+
+		case crNoPermission:
 		{
 			// The player is not allowed to execute this command
 			a_Player.SendMessageFailure(Printf("Forbidden command; insufficient privileges: \"%s\"", a_Message.c_str()));

--- a/src/Bindings/PluginManager.h
+++ b/src/Bindings/PluginManager.h
@@ -137,6 +137,7 @@ public:
 		HOOK_PRE_CRAFTING,
 		HOOK_PROJECTILE_HIT_BLOCK,
 		HOOK_PROJECTILE_HIT_ENTITY,
+		HOOK_RESOURCEPACK,
 		HOOK_SERVER_PING,
 		HOOK_SPAWNED_ENTITY,
 		HOOK_SPAWNED_MONSTER,
@@ -294,6 +295,7 @@ public:
 	bool CallHookPreCrafting              (cPlayer & a_Player, cCraftingGrid & a_Grid, cCraftingRecipe & a_Recipe);
 	bool CallHookProjectileHitBlock       (cProjectileEntity & a_Projectile, Vector3i a_BlockPos, eBlockFace a_Face, const Vector3d & a_BlockHitPos);
 	bool CallHookProjectileHitEntity      (cProjectileEntity & a_Projectile, cEntity & a_HitEntity);
+	bool CallHookResourcePack             (const UInt8 a_Status);
 	bool CallHookServerPing               (cClientHandle & a_ClientHandle, AString & a_ServerDescription, int & a_OnlinePlayersCount, int & a_MaxPlayersCount, AString & a_Favicon);
 	bool CallHookSpawnedEntity            (cWorld & a_World, cEntity & a_Entity);
 	bool CallHookSpawnedMonster           (cWorld & a_World, cMonster & a_Monster);

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -1884,10 +1884,10 @@ void cClientHandle::HandleUseItem(bool a_UsedMainHand)
 
 
 
+// @param a_Status 0: successfully loaded, 1: declined, 2: failed download, 3: accepted
 void cClientHandle::HandleResourcePack(UInt8 a_Status)
 {
-	// Kick player if client declined the resource pack
-	if (a_Status == 1)
+	if (cRoot::Get()->GetPluginManager()->CallHookResourcePack(a_Status))
 		Kick("You must accept the resource pack");
 }
 


### PR DESCRIPTION
Theses changes would be for using hook with resource pack and thus allowing plugin developer to tweak the action behind allowing or not the resource pack

Hope this help your pr, I don't have much time to do docs and all so this is just a "draft" 

I tested it with this little plugin and it worked

```PLUGIN = nil

function Initialize(Plugin)
	Plugin:SetName("TestPlugin")
	Plugin:SetVersion(1)

	-- Hooks

	cPluginManager.AddHook(cPluginManager.HOOK_RESOURCEPACK, myfunction)

	PLUGIN = Plugin -- NOTE: only needed if you want OnDisable() to use GetName() or something like that

	-- Command Bindings

	LOG("Initialised version " .. Plugin:GetVersion())
	return true
end

function OnDisable()
	LOG("Shutting down...")
end

function myfunction(status)
	LOG("The player came with :" .. status)
	if status == 1 or status == 2 then
		return true
	end
end
```